### PR TITLE
Bug: restore climate_now_capability definition so existing devices can self-migrate

### DIFF
--- a/.homeycompose/capabilities/climate_now_capability.json
+++ b/.homeycompose/capabilities/climate_now_capability.json
@@ -1,0 +1,10 @@
+{
+  "type": "boolean",
+  "title": {
+    "en": "Climate now",
+    "nl": "Nu klimatiseren"
+  },
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor"
+}

--- a/app.json
+++ b/app.json
@@ -1133,6 +1133,16 @@
       "uiComponent": "sensor",
       "icon": "/assets/evcharging.svg"
     },
+    "climate_now_capability": {
+      "type": "boolean",
+      "title": {
+        "en": "Climate now",
+        "nl": "Nu klimatiseren"
+      },
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
     "mileage_capability": {
       "type": "number",
       "title": {


### PR DESCRIPTION
## Problem

After the CarData API migration (PR #98) removed climate control support, the
`climate_now_capability` definition was also removed from
`.homeycompose/capabilities/`. This breaks **all existing devices** that still
have the capability registered on them:

> Device Unavailable — Invalid Capability: climate_now_capability

Homey validates every registered device capability against the app's known
definitions **before** running any app code. Because the definition is missing,
the device never loads, and the `removeCapabilitySafe(Capabilities.CLIMATE_NOW)`
call in `migrate_device_capabilities()` never executes — so the device stays
broken permanently.

## Fix

Add the capability definition back as a boolean stub. This lets Homey load
the device, run the migration, and permanently remove the capability. On the
next restart the capability is gone and the device works normally.

The stub type (`boolean`) matches the original capability used to represent
"climate is currently running".

## Testing

Deploy to a Homey that has a device stuck in "Invalid Capability:
climate_now_capability" — after one restart with this fix the device
comes back online.