### PR TITLE
Bug: fix four correctness issues in Vehicle.ts

### DIFF
--- a/drivers/Vehicle.ts
+++ b/drivers/Vehicle.ts
@@ -573,7 +573,7 @@ export class Vehicle extends Device {
         const oldFuelValue = this.currentVehicleState?.combustion?.fuelLevelLiters;
         // Trigger refuelled flow if fuel level increased beyond threshold
         if (
-          oldFuelValue &&
+          oldFuelValue !== undefined &&
           newFuelValue - oldFuelValue >= this.settings.refuellingTriggerThreshold
         ) {
           const refuelledFlowCard = this.homey.flow.getDeviceTriggerCard(Flows.REFUELLED);
@@ -626,6 +626,14 @@ export class Vehicle extends Device {
     await this.removeCapabilitySafe(Capabilities.AC_CHARGING_LIMIT); // AC limit control
     await this.removeCapabilitySafe(Capabilities.CHARGING_TARGET_SOC); // Target charge control
 
+    // Migrate device class to 'car' for Homey v12+ regardless of drivetrain state
+    if (semver.gte(this.homey.version, '12.0.0')) {
+      if (this.getClass() === 'other') {
+        this.logger?.info(`Migrating device class for '${this.getName()}' to 'car'.`);
+        await this.setClass('car');
+      }
+    }
+
     // Get drive train type from persisted store (set during initialization)
     const driveTrain = this.stateManager.getDriveTrain();
     if (driveTrain == DriveTrainType.UNKNOWN) {
@@ -647,12 +655,19 @@ export class Vehicle extends Device {
     if (hasElectricDriveTrain) {
       this.logger?.info(`Vehicle '${this.getName()}' has electric drive train.`);
       await this.addCapabilitySafe(Capabilities.MEASURE_BATTERY);
-      await this.addCapabilitySafe(Capabilities.RANGE_BATTERY);
       await this.addCapabilitySafe(Capabilities.EV_CHARGING_STATE);
     } else {
       await this.removeCapabilitySafe(Capabilities.MEASURE_BATTERY);
       await this.removeCapabilitySafe(Capabilities.RANGE_BATTERY);
       await this.removeCapabilitySafe(Capabilities.EV_CHARGING_STATE);
+    }
+
+    // RANGE_BATTERY (electric range) is only meaningful alongside a combustion range.
+    // Pure BEVs use range_capability directly; PHEVs/range-extenders need both.
+    if (hasElectricDriveTrain && hasCombustionDriveTrain) {
+      await this.addCapabilitySafe(Capabilities.RANGE_BATTERY);
+    } else {
+      await this.removeCapabilitySafe(Capabilities.RANGE_BATTERY);
     }
 
     // Remove legacy CHARGING_STATUS capability
@@ -670,14 +685,6 @@ export class Vehicle extends Device {
       await this.addCapabilitySafe(Capabilities.RANGE);
     } else {
       await this.removeCapabilitySafe(Capabilities.RANGE);
-    }
-
-    // Migrate device class to 'car' for Homey v12+
-    if (semver.gte(this.homey.version, '12.0.0')) {
-      if (this.getClass() === 'other') {
-        this.logger?.info(`Migrating device class for '${this.getName()}' to 'car'.`);
-        await this.setClass('car');
-      }
     }
 
     // Add EV charging state capability for Homey v12.4.5+
@@ -1043,7 +1050,7 @@ export class Vehicle extends Device {
       const position = configuration.geofences.find(
         (fence) =>
           fence?.longitude &&
-          fence?.longitude &&
+          fence?.latitude &&
           geo.insideCircle(location, fence, fence.radius ?? 20)
       );
       if (position) {

--- a/tests/drivers/Vehicle.capabilityMigration.test.ts
+++ b/tests/drivers/Vehicle.capabilityMigration.test.ts
@@ -100,7 +100,8 @@ describe('Vehicle Capability Migration Tests', () => {
 
       // Assert
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.MEASURE_BATTERY);
-      expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
+      // Pure BEV: RANGE_BATTERY is removed (only PHEVs/range-extenders need it alongside combustion range)
+      expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.EV_CHARGING_STATE);
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE);
     });
@@ -213,6 +214,19 @@ describe('Vehicle Capability Migration Tests', () => {
       );
       // No capability changes should be made (beyond removing remote service capabilities)
     });
+
+    it('should_migrateDeviceClass_when_drivetrainUnknown', async () => {
+      // Arrange — drivetrain unknown (e.g. API unreachable on first boot)
+      const mockStateManager = vehicle['stateManager'] as any;
+      mockStateManager.getDriveTrain.mockReturnValue(DriveTrainType.UNKNOWN);
+
+      // Act
+      await vehicle['migrate_device_capabilities']();
+
+      // Assert — setClass must run before the UNKNOWN early-return so devices
+      // stuck as 'other' get promoted to 'car' even when drivetrain is missing
+      expect(vehicle.setClass).toHaveBeenCalledWith('car');
+    });
   });
 
   describe('Device Class Migration', () => {
@@ -230,6 +244,34 @@ describe('Vehicle Capability Migration Tests', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('Migrating device class')
       );
+    });
+  });
+
+  describe('RANGE_BATTERY capability', () => {
+    it('should_not_addRangeBattery_for_pureElectric', async () => {
+      // Arrange — pure BEV already has range via range_capability; separate
+      // RANGE_BATTERY tile would always stay empty and confuse users
+      const mockStateManager = vehicle['stateManager'] as any;
+      mockStateManager.getDriveTrain.mockReturnValue(DriveTrainType.ELECTRIC);
+
+      // Act
+      await vehicle['migrate_device_capabilities']();
+
+      // Assert
+      expect(addCapabilitySafeSpy).not.toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
+      expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
+    });
+
+    it('should_addRangeBattery_for_phev', async () => {
+      // Arrange — PHEV has both combustion and electric ranges; both tiles are meaningful
+      const mockStateManager = vehicle['stateManager'] as any;
+      mockStateManager.getDriveTrain.mockReturnValue(DriveTrainType.PLUGIN_HYBRID);
+
+      // Act
+      await vehicle['migrate_device_capabilities']();
+
+      // Assert
+      expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
     });
   });
 

--- a/tests/drivers/Vehicle.geofencing.test.ts
+++ b/tests/drivers/Vehicle.geofencing.test.ts
@@ -221,6 +221,36 @@ describe('Vehicle Geofencing and Location', () => {
       expect(mockLogger.info).toHaveBeenCalledWith('Checking geofences.');
     });
 
+    it('should_skipGeofence_when_latitudeMissing', async () => {
+      // Arrange — geofence has longitude but no latitude; previously the guard
+      // checked longitude twice (copy-paste typo) so this fence would reach
+      // insideCircle() with undefined latitude, producing wrong results
+      mockConfiguration.geofences = [
+        {
+          label: 'BrokenFence',
+          longitude: -0.1278,
+          // latitude intentionally absent
+          address: 'Test',
+          radius: 50,
+        } as any,
+      ];
+      const location: LocationType = {
+        label: '',
+        latitude: 51.5074,
+        longitude: -0.1278,
+        address: 'Test',
+      };
+      (geo.insideCircle as jest.Mock).mockClear();
+      (geo.insideCircle as jest.Mock).mockReturnValue(true);
+
+      // Act
+      await vehicle['checkGeofence'](location);
+
+      // Assert — insideCircle must not be called for a fence with no latitude
+      expect(geo.insideCircle).not.toHaveBeenCalled();
+      expect(location.label).toBe('');
+    });
+
     it('should_doNothing_when_configurationNull', async () => {
       // Arrange
       jest.spyOn(ConfigurationManager, 'getConfiguration').mockReturnValue(null as any);

--- a/tests/drivers/Vehicle.refueling.test.ts
+++ b/tests/drivers/Vehicle.refueling.test.ts
@@ -221,6 +221,48 @@ describe('Vehicle Refueling Flow', () => {
       expect(mockRefuelledFlowCard.trigger).not.toHaveBeenCalled();
     });
 
+    it('should_triggerRefuelledFlow_when_refueledFromEmptyTank', async () => {
+      // Arrange — oldFuelValue is 0 (completely empty); `oldFuelValue &&` would be
+      // falsy and suppress the trigger, but `oldFuelValue !== undefined` correctly fires it
+      vehicle.currentVehicleState = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.COMBUSTION,
+        lastUpdatedAt: new Date('2025-11-04T10:00:00Z'),
+        combustion: {
+          fuelLevelLiters: 0, // completely empty
+          fuelLevelPercent: 0,
+        },
+        range: 0,
+      } as VehicleStatus;
+
+      const newStatus: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.COMBUSTION,
+        lastUpdatedAt: new Date('2025-11-04T10:10:00Z'),
+        combustion: {
+          fuelLevelLiters: 40, // refueled 40 liters (>5 threshold)
+          fuelLevelPercent: 60,
+        },
+        range: 400,
+      };
+
+      // Act
+      await (vehicle as any).updateCapabilitiesFromStatus(newStatus);
+
+      // Assert — flow must fire even though oldFuelValue was 0
+      expect(mockRefuelledFlowCard.trigger).toHaveBeenCalledTimes(1);
+      expect(mockRefuelledFlowCard.trigger).toHaveBeenCalledWith(
+        vehicle,
+        {
+          FuelBeforeRefuelling: 0,
+          FuelAfterRefuelling: 40,
+          RefuelledLiters: 40,
+          Location: '',
+        },
+        {}
+      );
+    });
+
     it('should_notTriggerRefuelledFlow_when_noPreviousFuelValue', async () => {
       // Arrange - No previous state (first update after pairing)
       vehicle.currentVehicleState = null;


### PR DESCRIPTION
## Fixes

### 1. Geofence latitude check — copy-paste typo

```ts
// before
fence?.longitude &&
fence?.longitude &&   // ← always checked longitude twice

// after
fence?.longitude &&
fence?.latitude &&
```

A geofence with `latitude` not set (or set to `0`) would pass the guard
and reach `geo.insideCircle()` with an undefined/zero latitude, producing
wrong results silently.

---

### 2. Refuelling trigger skips when tank is empty

```ts
// before
if (oldFuelValue && newFuelValue - oldFuelValue >= threshold)

// after
if (oldFuelValue !== undefined && newFuelValue - oldFuelValue >= threshold)
```

`oldFuelValue &&` is falsy when the tank is at `0 L`. If a car ran
completely dry and was then refuelled, the flow trigger would never fire.

---

### 3. `setClass('car')` bypassed on unknown drivetrain

The `DriveTrainType.UNKNOWN` early return in `migrate_device_capabilities()`
was placed **before** the `setClass('car')` migration for Homey v12+. Devices
whose drivetrain hadn't been persisted yet (e.g. API unreachable on first
boot) would stay as `class: other` indefinitely.

Moved `setClass('car')` before the early return so it always runs.

---

### 4. `RANGE_BATTERY` added for pure BEVs but never populated

`range_capability.battery` was added for all `HV_BATTERY_DRIVE_TRAINS`
(including pure BEVs), but `setCapabilityValueSafe(Capabilities.RANGE_BATTERY)`
is only called when `status.combustion` is present (PHEVs / range-extenders).

Pure BEVs ended up with a permanently empty tile. For pure BEVs,
`range_capability` already shows the full battery range. The separate
`RANGE_BATTERY` capability is now only added when both electric **and**
combustion drivetrains are present (i.e. PHEVs and range-extenders).