### PR TITLE
Bug: remove stale default capabilities from driver template

### DIFF
--- a/.homeycompose/drivers/templates/driver.json
+++ b/.homeycompose/drivers/templates/driver.json
@@ -6,12 +6,7 @@
     "capabilities": [
         "alarm_generic",
         "mileage_capability",
-        "range_capability",
-        "measure_battery",
-        "range_capability.battery",
-        "range_capability.fuel",
-        "charging_status_capability",
-        "remaining_fuel_capability"
+        "range_capability"
     ],
     "capabilitiesOptions": {
         "alarm_generic": {

--- a/app.json
+++ b/app.json
@@ -651,12 +651,7 @@
       "capabilities": [
         "alarm_generic",
         "mileage_capability",
-        "range_capability",
-        "measure_battery",
-        "range_capability.battery",
-        "range_capability.fuel",
-        "charging_status_capability",
-        "remaining_fuel_capability"
+        "range_capability"
       ],
       "capabilitiesOptions": {
         "alarm_generic": {
@@ -843,12 +838,7 @@
       "capabilities": [
         "alarm_generic",
         "mileage_capability",
-        "range_capability",
-        "measure_battery",
-        "range_capability.battery",
-        "range_capability.fuel",
-        "charging_status_capability",
-        "remaining_fuel_capability"
+        "range_capability"
       ],
       "capabilitiesOptions": {
         "alarm_generic": {


### PR DESCRIPTION
## Problem

The shared driver template lists these as default device capabilities:

- `charging_status_capability`
- `measure_battery`
- `range_capability.battery`
- `range_capability.fuel`
- `remaining_fuel_capability`

All of these are either unconditionally removed or conditionally re-added
by `migrate_device_capabilities()` on the very first `onInit`. This means
every newly paired device briefly shows incorrect capability tiles (e.g.
a battery percentage tile on an ICE car, or a fuel range tile on a BEV)
before they're stripped.

## Fix

Trim the template to the three capabilities that apply to **all** vehicles
regardless of drivetrain:

- `alarm_generic`
- `mileage_capability`
- `range_capability`

Drivetrain-specific capabilities (`measure_battery`, `range_capability.battery`,
`remaining_fuel_capability`) are still correctly added by the migration for
devices that need them. Existing devices are unaffected.