### PR TITLE
Fix: implement isAuthenticated() using token expiry check

### DIFF
--- a/lib/api/CarDataClient.ts
+++ b/lib/api/CarDataClient.ts
@@ -186,10 +186,9 @@ export class CarDataClient implements IVehicleClient {
    * @returns True if authenticated with valid tokens
    */
   isAuthenticated(): boolean {
-    // Note: IVehicleClient requires synchronous check
-    // We assume authenticated if auth provider exists
-    // Actual token validity checked during API calls
-    return true; // TODO: Improve synchronous auth check
+    // Returns true only when a non-expired access token is cached in memory.
+    // An expired access token is refreshed lazily on the next API call.
+    return !this.authProvider.isAccessTokenExpired();
   }
 
   /**

--- a/tests/drivers/Vehicle.capabilityMigration.test.ts
+++ b/tests/drivers/Vehicle.capabilityMigration.test.ts
@@ -100,10 +100,10 @@ describe('Vehicle Capability Migration Tests', () => {
 
       // Assert
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.MEASURE_BATTERY);
-      // Pure BEV: RANGE_BATTERY is removed (only PHEVs/range-extenders need it alongside combustion range)
-      expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.EV_CHARGING_STATE);
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE);
+      // RANGE_BATTERY is only for PHEV (electric + combustion), not pure BEV
+      expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
     });
 
     it('should_removeElectricCapabilities_when_combustionDrivetrain', async () => {

--- a/tests/lib/api/CarDataClient.comprehensive.test.ts
+++ b/tests/lib/api/CarDataClient.comprehensive.test.ts
@@ -168,12 +168,16 @@ describe('CarDataClient - Comprehensive Tests', () => {
       expect(mockLogger.error).toHaveBeenCalledWith('Authentication failed', authError);
     });
 
-    it('should_returnTrue_when_isAuthenticated', () => {
-      // Act
-      const result = carDataClient.isAuthenticated();
+    it('should_returnTrue_when_accessTokenNotExpired', () => {
+      mockAuthProvider.isAccessTokenExpired.mockReturnValue(false);
 
-      // Assert
-      expect(result).toBe(true); // Current implementation always returns true
+      expect(carDataClient.isAuthenticated()).toBe(true);
+    });
+
+    it('should_returnFalse_when_accessTokenExpiredOrMissing', () => {
+      mockAuthProvider.isAccessTokenExpired.mockReturnValue(true);
+
+      expect(carDataClient.isAuthenticated()).toBe(false);
     });
 
     it('should_refreshTokens_when_refreshAuthenticationCalled', async () => {


### PR DESCRIPTION
## Summary
- Replaces the `return true` stub in `CarDataClient.isAuthenticated()` with a real check: `!this.authProvider.isAccessTokenExpired()`
- Callers that gate actions on `isAuthenticated()` (e.g. skip polling when not logged in) now get a truthful answer
- Expired tokens are still refreshed lazily on the next API call, no change to the refresh flow

## Test plan
- [ ] `should_returnTrue_when_accessTokenNotExpired` passes
- [ ] `should_returnFalse_when_accessTokenExpiredOrMissing` passes (new test)
- [ ] Full test suite passes