### PR TITLE
Feat: expose door and window combined state as Homey capabilities

### DIFF
--- a/.homeycompose/capabilities/door_state_capability.json
+++ b/.homeycompose/capabilities/door_state_capability.json
@@ -1,0 +1,15 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Doors",
+    "nl": "Deuren"
+  },
+  "values": [
+    { "id": "OPEN", "title": { "en": "Open", "nl": "Open" } },
+    { "id": "CLOSED", "title": { "en": "Closed", "nl": "Gesloten" } },
+    { "id": "UNKNOWN", "title": { "en": "Unknown", "nl": "Onbekend" } }
+  ],
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor"
+}

--- a/.homeycompose/capabilities/window_state_capability.json
+++ b/.homeycompose/capabilities/window_state_capability.json
@@ -1,0 +1,16 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Windows",
+    "nl": "Ramen"
+  },
+  "values": [
+    { "id": "OPEN", "title": { "en": "Open", "nl": "Open" } },
+    { "id": "CLOSED", "title": { "en": "Closed", "nl": "Gesloten" } },
+    { "id": "INTERMEDIATE", "title": { "en": "Intermediate", "nl": "Tussenstand" } },
+    { "id": "UNKNOWN", "title": { "en": "Unknown", "nl": "Onbekend" } }
+  ],
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor"
+}

--- a/app.json
+++ b/app.json
@@ -1133,6 +1133,39 @@
       "setable": false,
       "uiComponent": "sensor"
     },
+    "door_state_capability": {
+      "type": "enum",
+      "title": {
+        "en": "Doors",
+        "nl": "Deuren"
+      },
+      "values": [
+        {
+          "id": "OPEN",
+          "title": {
+            "en": "Open",
+            "nl": "Open"
+          }
+        },
+        {
+          "id": "CLOSED",
+          "title": {
+            "en": "Closed",
+            "nl": "Gesloten"
+          }
+        },
+        {
+          "id": "UNKNOWN",
+          "title": {
+            "en": "Unknown",
+            "nl": "Onbekend"
+          }
+        }
+      ],
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
     "mileage_capability": {
       "type": "number",
       "title": {
@@ -1171,39 +1204,6 @@
       "icon": "/assets/gas-station.svg",
       "units": "l",
       "insights": true
-    },
-    "door_state_capability": {
-      "type": "enum",
-      "title": {
-        "en": "Doors",
-        "nl": "Deuren"
-      },
-      "values": [
-        {
-          "id": "OPEN",
-          "title": {
-            "en": "Open",
-            "nl": "Open"
-          }
-        },
-        {
-          "id": "CLOSED",
-          "title": {
-            "en": "Closed",
-            "nl": "Gesloten"
-          }
-        },
-        {
-          "id": "UNKNOWN",
-          "title": {
-            "en": "Unknown",
-            "nl": "Onbekend"
-          }
-        }
-      ],
-      "getable": true,
-      "setable": false,
-      "uiComponent": "sensor"
     },
     "window_state_capability": {
       "type": "enum",

--- a/app.json
+++ b/app.json
@@ -1171,6 +1171,79 @@
       "icon": "/assets/gas-station.svg",
       "units": "l",
       "insights": true
+    },
+    "door_state_capability": {
+      "type": "enum",
+      "title": {
+        "en": "Doors",
+        "nl": "Deuren"
+      },
+      "values": [
+        {
+          "id": "OPEN",
+          "title": {
+            "en": "Open",
+            "nl": "Open"
+          }
+        },
+        {
+          "id": "CLOSED",
+          "title": {
+            "en": "Closed",
+            "nl": "Gesloten"
+          }
+        },
+        {
+          "id": "UNKNOWN",
+          "title": {
+            "en": "Unknown",
+            "nl": "Onbekend"
+          }
+        }
+      ],
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
+    "window_state_capability": {
+      "type": "enum",
+      "title": {
+        "en": "Windows",
+        "nl": "Ramen"
+      },
+      "values": [
+        {
+          "id": "OPEN",
+          "title": {
+            "en": "Open",
+            "nl": "Open"
+          }
+        },
+        {
+          "id": "CLOSED",
+          "title": {
+            "en": "Closed",
+            "nl": "Gesloten"
+          }
+        },
+        {
+          "id": "INTERMEDIATE",
+          "title": {
+            "en": "Intermediate",
+            "nl": "Tussenstand"
+          }
+        },
+        {
+          "id": "UNKNOWN",
+          "title": {
+            "en": "Unknown",
+            "nl": "Onbekend"
+          }
+        }
+      ],
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
     }
   }
 }

--- a/drivers/Vehicle.ts
+++ b/drivers/Vehicle.ts
@@ -485,16 +485,15 @@ export class Vehicle extends Device {
       }
     }
 
-    // TODO: Add door and window capabilities to Capabilities.ts and app.json
     // Update doors
-    // if (status.doors) {
-    //   await this.updateCapabilityValue('door_state_capability', status.doors.combinedState);
-    // }
+    if (status.doors) {
+      await this.setCapabilityValueSafe(Capabilities.DOOR_STATE, status.doors.combinedState);
+    }
 
     // Update windows
-    // if (status.windows) {
-    //   await this.updateCapabilityValue('window_state_capability', status.windows.combinedState);
-    // }
+    if (status.windows) {
+      await this.setCapabilityValueSafe(Capabilities.WINDOW_STATE, status.windows.combinedState);
+    }
 
     // Update lock state (read-only status, not control)
     if (status.lockState) {
@@ -686,6 +685,10 @@ export class Vehicle extends Device {
     } else {
       await this.removeCapabilitySafe(Capabilities.RANGE);
     }
+
+    // Door and window state capabilities are available for all vehicles
+    await this.addCapabilitySafe(Capabilities.DOOR_STATE);
+    await this.addCapabilitySafe(Capabilities.WINDOW_STATE);
 
     // Add EV charging state capability for Homey v12.4.5+
     if (semver.gte(this.homey.version, '12.4.5') && hasElectricDriveTrain) {

--- a/tests/drivers/Vehicle.capabilityMigration.test.ts
+++ b/tests/drivers/Vehicle.capabilityMigration.test.ts
@@ -100,10 +100,10 @@ describe('Vehicle Capability Migration Tests', () => {
 
       // Assert
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.MEASURE_BATTERY);
-      // Pure BEV: RANGE_BATTERY is removed (only PHEVs/range-extenders need it alongside combustion range)
-      expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.EV_CHARGING_STATE);
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE);
+      // RANGE_BATTERY is only for PHEV (electric + combustion), not pure BEV
+      expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
     });
 
     it('should_removeElectricCapabilities_when_combustionDrivetrain', async () => {
@@ -272,6 +272,28 @@ describe('Vehicle Capability Migration Tests', () => {
 
       // Assert
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE_BATTERY);
+    });
+  });
+
+  describe('Door and Window Capabilities', () => {
+    it('should_addDoorAndWindowCapabilities_when_electricDrivetrain', async () => {
+      const mockStateManager = vehicle['stateManager'] as any;
+      mockStateManager.getDriveTrain.mockReturnValue(DriveTrainType.ELECTRIC);
+
+      await vehicle['migrate_device_capabilities']();
+
+      expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.DOOR_STATE);
+      expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.WINDOW_STATE);
+    });
+
+    it('should_addDoorAndWindowCapabilities_when_combustionDrivetrain', async () => {
+      const mockStateManager = vehicle['stateManager'] as any;
+      mockStateManager.getDriveTrain.mockReturnValue(DriveTrainType.COMBUSTION);
+
+      await vehicle['migrate_device_capabilities']();
+
+      expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.DOOR_STATE);
+      expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.WINDOW_STATE);
     });
   });
 

--- a/tests/drivers/Vehicle.updateCapabilities.test.ts
+++ b/tests/drivers/Vehicle.updateCapabilities.test.ts
@@ -93,6 +93,70 @@ describe('Vehicle.updateCapabilitiesFromStatus', () => {
     jest.restoreAllMocks();
   });
 
+  describe('Door and Window State', () => {
+    it('should_updateDoorState_when_doorsPresent', async () => {
+      const status: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.ELECTRIC,
+        lastUpdatedAt: new Date(),
+        doors: {
+          combinedState: 'OPEN',
+          leftFront: 'OPEN',
+          rightFront: 'CLOSED',
+          leftRear: 'CLOSED',
+          rightRear: 'CLOSED',
+          hood: 'CLOSED',
+          trunk: 'CLOSED',
+        },
+      };
+
+      await (vehicle as any).updateCapabilitiesFromStatus(status);
+
+      expect(setCapabilityValueSafeSpy).toHaveBeenCalledWith(Capabilities.DOOR_STATE, 'OPEN');
+    });
+
+    it('should_updateWindowState_when_windowsPresent', async () => {
+      const status: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.ELECTRIC,
+        lastUpdatedAt: new Date(),
+        windows: {
+          combinedState: 'INTERMEDIATE',
+          leftFront: 'INTERMEDIATE',
+          rightFront: 'CLOSED',
+          leftRear: 'CLOSED',
+          rightRear: 'CLOSED',
+        },
+      };
+
+      await (vehicle as any).updateCapabilitiesFromStatus(status);
+
+      expect(setCapabilityValueSafeSpy).toHaveBeenCalledWith(
+        Capabilities.WINDOW_STATE,
+        'INTERMEDIATE'
+      );
+    });
+
+    it('should_notUpdateDoorOrWindowState_when_bothAbsent', async () => {
+      const status: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.ELECTRIC,
+        lastUpdatedAt: new Date(),
+      };
+
+      await (vehicle as any).updateCapabilitiesFromStatus(status);
+
+      expect(setCapabilityValueSafeSpy).not.toHaveBeenCalledWith(
+        Capabilities.DOOR_STATE,
+        expect.anything()
+      );
+      expect(setCapabilityValueSafeSpy).not.toHaveBeenCalledWith(
+        Capabilities.WINDOW_STATE,
+        expect.anything()
+      );
+    });
+  });
+
   describe('P0: Undefined Handling', () => {
     it('should_updateAllCapabilities_when_validStatusProvided', async () => {
       // Arrange

--- a/utils/Capabilities.ts
+++ b/utils/Capabilities.ts
@@ -38,6 +38,10 @@ export class Capabilities {
   // Vehicle information capabilities
   public static readonly MILEAGE = 'mileage_capability';
 
+  // Door and window state capabilities
+  public static readonly DOOR_STATE = 'door_state_capability';
+  public static readonly WINDOW_STATE = 'window_state_capability';
+
   // Climate capabilities
   public static readonly CLIMATE_NOW = 'climate_now_capability';
 
@@ -62,6 +66,8 @@ export class Capabilities {
     Capabilities.LOCATION,
     Capabilities.ADDRESS,
     Capabilities.MILEAGE,
+    Capabilities.DOOR_STATE,
+    Capabilities.WINDOW_STATE,
     Capabilities.CLIMATE_NOW,
   ];
 


### PR DESCRIPTION
## Summary
- Adds two new capabilities: `door_state_capability` (OPEN/CLOSED/UNKNOWN) and `window_state_capability` (OPEN/CLOSED/INTERMEDIATE/UNKNOWN)
- Both are added for all drivetrains since every vehicle has doors and windows
- Wires `status.doors.combinedState` and `status.windows.combinedState` through to `setCapabilityValueSafe`
- Capability JSON definitions added under `.homeycompose/capabilities/`
- Enum values match exactly what `TelematicDataTransformer` emits; INVALID is never produced by any transformer path and is intentionally excluded

## Test plan
- [ ] Migration adds both capabilities for all drivetrain types
- [ ] `npx jest` passes
- [ ] `homey app validate` passes