### PR TITLE
Feat: expose fuel level percentage as a capability for combustion vehicles

### DIFF
--- a/.homeycompose/capabilities/fuel_level_percent_capability.json
+++ b/.homeycompose/capabilities/fuel_level_percent_capability.json
@@ -1,0 +1,15 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Fuel level",
+    "nl": "Brandstofniveau"
+  },
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor",
+  "icon": "/assets/gas-station.svg",
+  "units": "%",
+  "min": 0,
+  "max": 100,
+  "insights": true
+}

--- a/drivers/Vehicle.ts
+++ b/drivers/Vehicle.ts
@@ -557,10 +557,12 @@ export class Vehicle extends Device {
 
     // Update combustion vehicle data
     if (status.combustion) {
-      // TODO: Add fuel level percentage capability if needed
-      // if (status.combustion.fuelLevelPercent !== undefined) {
-      //   await this.updateCapabilityValue('fuel_level_percentage', status.combustion.fuelLevelPercent);
-      // }
+      if (status.combustion.fuelLevelPercent !== undefined) {
+        await this.setCapabilityValueSafe(
+          Capabilities.FUEL_LEVEL_PERCENT,
+          status.combustion.fuelLevelPercent
+        );
+      }
 
       const newFuelValue = status.combustion.fuelLevelLiters;
       if (newFuelValue !== undefined) {
@@ -676,8 +678,10 @@ export class Vehicle extends Device {
     if (hasCombustionDriveTrain) {
       this.logger?.info(`Vehicle '${this.getName()}' has combustion drive train.`);
       await this.addCapabilitySafe(Capabilities.REMAINING_FUEL);
+      await this.addCapabilitySafe(Capabilities.FUEL_LEVEL_PERCENT);
     } else {
       await this.removeCapabilitySafe(Capabilities.REMAINING_FUEL);
+      await this.removeCapabilitySafe(Capabilities.FUEL_LEVEL_PERCENT);
     }
 
     if (hasElectricDriveTrain || hasCombustionDriveTrain) {

--- a/tests/drivers/Vehicle.capabilityMigration.test.ts
+++ b/tests/drivers/Vehicle.capabilityMigration.test.ts
@@ -136,10 +136,11 @@ describe('Vehicle Capability Migration Tests', () => {
 
       // Assert
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.REMAINING_FUEL);
+      expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.FUEL_LEVEL_PERCENT);
       expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.RANGE);
     });
 
-    it('should_removeFuelCapability_when_electricDrivetrain', async () => {
+    it('should_removeFuelCapabilities_when_electricDrivetrain', async () => {
       // Arrange
       const electricStatus = createMockVehicleStatus(DriveTrainType.ELECTRIC);
       const mockStateManager = vehicle['stateManager'] as any;
@@ -151,6 +152,7 @@ describe('Vehicle Capability Migration Tests', () => {
 
       // Assert
       expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.REMAINING_FUEL);
+      expect(removeCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.FUEL_LEVEL_PERCENT);
     });
   });
 

--- a/tests/drivers/Vehicle.updateCapabilities.test.ts
+++ b/tests/drivers/Vehicle.updateCapabilities.test.ts
@@ -157,6 +157,42 @@ describe('Vehicle.updateCapabilitiesFromStatus', () => {
     });
   });
 
+  describe('Fuel Level Percent', () => {
+    it('should_updateFuelLevelPercent_when_fuelLevelPercentPresent', async () => {
+      const status: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.COMBUSTION,
+        lastUpdatedAt: new Date(),
+        combustion: {
+          fuelLevelPercent: 72,
+          fuelLevelLiters: 36,
+        },
+      };
+
+      await (vehicle as any).updateCapabilitiesFromStatus(status);
+
+      expect(setCapabilityValueSafeSpy).toHaveBeenCalledWith(Capabilities.FUEL_LEVEL_PERCENT, 72);
+    });
+
+    it('should_notUpdateFuelLevelPercent_when_fuelLevelPercentUndefined', async () => {
+      const status: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.COMBUSTION,
+        lastUpdatedAt: new Date(),
+        combustion: {
+          fuelLevelLiters: 36,
+        },
+      };
+
+      await (vehicle as any).updateCapabilitiesFromStatus(status);
+
+      expect(setCapabilityValueSafeSpy).not.toHaveBeenCalledWith(
+        Capabilities.FUEL_LEVEL_PERCENT,
+        expect.anything()
+      );
+    });
+  });
+
   describe('P0: Undefined Handling', () => {
     it('should_updateAllCapabilities_when_validStatusProvided', async () => {
       // Arrange

--- a/utils/Capabilities.ts
+++ b/utils/Capabilities.ts
@@ -30,6 +30,7 @@ export class Capabilities {
   public static readonly REMAINING_FUEL = 'remaining_fuel_capability';
   // Note: This constant includes the typo from the original code for backward compatibility
   public static readonly REMAINING_FUEL_LITERS_TYPO = 'remanining_fuel_liters_capability';
+  public static readonly FUEL_LEVEL_PERCENT = 'fuel_level_percent_capability';
 
   // Location capabilities
   public static readonly LOCATION = 'location_capability';
@@ -63,6 +64,7 @@ export class Capabilities {
     Capabilities.REMAINING_FUEL_LITERS,
     Capabilities.REMAINING_FUEL,
     Capabilities.REMAINING_FUEL_LITERS_TYPO,
+    Capabilities.FUEL_LEVEL_PERCENT,
     Capabilities.LOCATION,
     Capabilities.ADDRESS,
     Capabilities.MILEAGE,


### PR DESCRIPTION
## Summary
- Adds `fuel_level_percent_capability` (0-100%, insights enabled) for combustion and hybrid vehicles
- Added during migration for COMBUSTION drivetrain; removed for ELECTRIC
- Wires `status.combustion.fuelLevelPercent` with an undefined guard since the field is optional
- Capability JSON added to `.homeycompose/capabilities/` with gas-station icon and percentage units

## Test plan
- [ ] Migration adds `FUEL_LEVEL_PERCENT` for combustion drivetrain
- [ ] Migration removes `FUEL_LEVEL_PERCENT` for electric drivetrain
- [ ] `npx jest` passes
- [ ] `homey app validate` passes