### PR TITLE
Feat: expose climate preconditioning status as a Homey capability

### DIFF
--- a/.homeycompose/capabilities/climate_status_capability.json
+++ b/.homeycompose/capabilities/climate_status_capability.json
@@ -1,0 +1,18 @@
+{
+  "type": "enum",
+  "title": {
+    "en": "Climate status",
+    "nl": "Klimaatstatus"
+  },
+  "values": [
+    { "id": "HEATING", "title": { "en": "Heating", "nl": "Verwarming" } },
+    { "id": "COOLING", "title": { "en": "Cooling", "nl": "Koeling" } },
+    { "id": "VENTILATION", "title": { "en": "Ventilation", "nl": "Ventilatie" } },
+    { "id": "INACTIVE", "title": { "en": "Inactive", "nl": "Inactief" } },
+    { "id": "UNKNOWN", "title": { "en": "Unknown", "nl": "Onbekend" } }
+  ],
+  "getable": true,
+  "setable": false,
+  "uiComponent": "sensor",
+  "icon": "/assets/airco.svg"
+}

--- a/app.json
+++ b/app.json
@@ -1244,6 +1244,54 @@
       "getable": true,
       "setable": false,
       "uiComponent": "sensor"
+    },
+    "climate_status_capability": {
+      "type": "enum",
+      "title": {
+        "en": "Climate status",
+        "nl": "Klimaatstatus"
+      },
+      "values": [
+        {
+          "id": "HEATING",
+          "title": {
+            "en": "Heating",
+            "nl": "Verwarming"
+          }
+        },
+        {
+          "id": "COOLING",
+          "title": {
+            "en": "Cooling",
+            "nl": "Koeling"
+          }
+        },
+        {
+          "id": "VENTILATION",
+          "title": {
+            "en": "Ventilation",
+            "nl": "Ventilatie"
+          }
+        },
+        {
+          "id": "INACTIVE",
+          "title": {
+            "en": "Inactive",
+            "nl": "Inactief"
+          }
+        },
+        {
+          "id": "UNKNOWN",
+          "title": {
+            "en": "Unknown",
+            "nl": "Onbekend"
+          }
+        }
+      ],
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor",
+      "icon": "/assets/airco.svg"
     }
   }
 }

--- a/drivers/Vehicle.ts
+++ b/drivers/Vehicle.ts
@@ -597,11 +597,10 @@ export class Vehicle extends Device {
       }
     }
 
-    // TODO: Add climate status capability if needed
-    // Update climate state
-    // if (status.climate) {
-    //   await this.updateCapabilityValue('climate_status', status.climate.activity);
-    // }
+    // Update climate preconditioning state
+    if (status.climate) {
+      await this.setCapabilityValueSafe(Capabilities.CLIMATE_STATUS, status.climate.activity);
+    }
 
     this.currentVehicleState = status;
 
@@ -693,6 +692,9 @@ export class Vehicle extends Device {
     // Door and window state capabilities are available for all vehicles
     await this.addCapabilitySafe(Capabilities.DOOR_STATE);
     await this.addCapabilitySafe(Capabilities.WINDOW_STATE);
+
+    // Climate preconditioning status is available for all vehicles
+    await this.addCapabilitySafe(Capabilities.CLIMATE_STATUS);
 
     // Add EV charging state capability for Homey v12.4.5+
     if (semver.gte(this.homey.version, '12.4.5') && hasElectricDriveTrain) {

--- a/tests/drivers/Vehicle.capabilityMigration.test.ts
+++ b/tests/drivers/Vehicle.capabilityMigration.test.ts
@@ -181,7 +181,11 @@ describe('Vehicle Capability Migration Tests', () => {
 
   describe('Climate Status Capability', () => {
     it('should_addClimateStatusCapability_for_all_drivetrains', async () => {
-      for (const driveTrain of [DriveTrainType.ELECTRIC, DriveTrainType.COMBUSTION, DriveTrainType.PLUGIN_HYBRID]) {
+      for (const driveTrain of [
+        DriveTrainType.ELECTRIC,
+        DriveTrainType.COMBUSTION,
+        DriveTrainType.PLUGIN_HYBRID,
+      ]) {
         const mockStateManager = vehicle['stateManager'] as any;
         mockStateManager.getDriveTrain.mockReturnValue(driveTrain);
         addCapabilitySafeSpy.mockClear();

--- a/tests/drivers/Vehicle.capabilityMigration.test.ts
+++ b/tests/drivers/Vehicle.capabilityMigration.test.ts
@@ -179,6 +179,20 @@ describe('Vehicle Capability Migration Tests', () => {
     });
   });
 
+  describe('Climate Status Capability', () => {
+    it('should_addClimateStatusCapability_for_all_drivetrains', async () => {
+      for (const driveTrain of [DriveTrainType.ELECTRIC, DriveTrainType.COMBUSTION, DriveTrainType.PLUGIN_HYBRID]) {
+        const mockStateManager = vehicle['stateManager'] as any;
+        mockStateManager.getDriveTrain.mockReturnValue(driveTrain);
+        addCapabilitySafeSpy.mockClear();
+
+        await vehicle['migrate_device_capabilities']();
+
+        expect(addCapabilitySafeSpy).toHaveBeenCalledWith(Capabilities.CLIMATE_STATUS);
+      }
+    });
+  });
+
   describe('Remote Service Capabilities Removal', () => {
     it('should_removeAllRemoteServiceCapabilities_when_migrating', async () => {
       // Arrange

--- a/tests/drivers/Vehicle.updateCapabilities.test.ts
+++ b/tests/drivers/Vehicle.updateCapabilities.test.ts
@@ -204,7 +204,10 @@ describe('Vehicle.updateCapabilitiesFromStatus', () => {
 
       await (vehicle as any).updateCapabilitiesFromStatus(status);
 
-      expect(setCapabilityValueSafeSpy).toHaveBeenCalledWith(Capabilities.CLIMATE_STATUS, 'HEATING');
+      expect(setCapabilityValueSafeSpy).toHaveBeenCalledWith(
+        Capabilities.CLIMATE_STATUS,
+        'HEATING'
+      );
     });
 
     it('should_notUpdateClimateStatus_when_climateAbsent', async () => {

--- a/tests/drivers/Vehicle.updateCapabilities.test.ts
+++ b/tests/drivers/Vehicle.updateCapabilities.test.ts
@@ -193,6 +193,36 @@ describe('Vehicle.updateCapabilitiesFromStatus', () => {
     });
   });
 
+  describe('Climate Status', () => {
+    it('should_updateClimateStatus_when_climatePresent', async () => {
+      const status: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.ELECTRIC,
+        lastUpdatedAt: new Date(),
+        climate: { activity: 'HEATING' },
+      };
+
+      await (vehicle as any).updateCapabilitiesFromStatus(status);
+
+      expect(setCapabilityValueSafeSpy).toHaveBeenCalledWith(Capabilities.CLIMATE_STATUS, 'HEATING');
+    });
+
+    it('should_notUpdateClimateStatus_when_climateAbsent', async () => {
+      const status: VehicleStatus = {
+        vin: 'WBA12345678901234',
+        driveTrain: DriveTrainType.ELECTRIC,
+        lastUpdatedAt: new Date(),
+      };
+
+      await (vehicle as any).updateCapabilitiesFromStatus(status);
+
+      expect(setCapabilityValueSafeSpy).not.toHaveBeenCalledWith(
+        Capabilities.CLIMATE_STATUS,
+        expect.anything()
+      );
+    });
+  });
+
   describe('P0: Undefined Handling', () => {
     it('should_updateAllCapabilities_when_validStatusProvided', async () => {
       // Arrange

--- a/utils/Capabilities.ts
+++ b/utils/Capabilities.ts
@@ -45,6 +45,7 @@ export class Capabilities {
 
   // Climate capabilities
   public static readonly CLIMATE_NOW = 'climate_now_capability';
+  public static readonly CLIMATE_STATUS = 'climate_status_capability';
 
   public static readonly ALL_CAPABILITIES: string[] = [
     Capabilities.LOCKED,
@@ -71,6 +72,7 @@ export class Capabilities {
     Capabilities.DOOR_STATE,
     Capabilities.WINDOW_STATE,
     Capabilities.CLIMATE_NOW,
+    Capabilities.CLIMATE_STATUS,
   ];
 
   public static async GetCapabilityValueSafe<T>(


### PR DESCRIPTION
## Summary
- Adds `climate_status_capability` (enum: HEATING/COOLING/VENTILATION/INACTIVE/UNKNOWN) for all vehicles
- Added for all drivetrains since climate preconditioning is available on both BEV and ICE
- Wires `status.climate.activity` through `setCapabilityValueSafe` (null-checked at `status.climate` level; `activity` is required)
- Capability JSON added to `.homeycompose/capabilities/` with airco icon
- Covers all 5 `ClimateActivity` values

## Test plan
- [ ] Migration adds `CLIMATE_STATUS` for all drivetrain types
- [ ] `npx jest` passes
- [ ] `homey app validate` passes